### PR TITLE
Fixed dependency and CSS selector issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,6 @@ Tool to convert VU-Amsterdam timetables (from [rooster.vu.nl](https://rooster.vu
     * Be sure to select *Type of Report*: `Module`, when generating the table.  
     * If you want to export the entire course timetable at once, select a semester in *Select Week(s)* (instead of single weeks).
 4. Once you are on the HTML page generated for you, hit <kbd>Ctrl-S</kbd> to save the page. To make sure you don't download the entire webpage, select 'HTML only' in the 'save as type' dropdown. Save the file in the cloned directory of this repo, under the name `input.html`.
+    * Note: If you are on macOS use Safari not Chrome. 
 5. Run `python main.py` from this directory.
 6. Your calendar file is waiting for you in this directory, called `output.ics`  Import it into the calendar of your choice!

--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ def get_calendar(soup):
 
     calendar = Calendar()
 
-    rows = soup.select('table tr')
+    rows = soup.select('table.spreadsheet tr')
 
     for row in rows:
         if re.search('\d+/\d+/\d+', str(row)) is None or not re.search('Printdatum', str(row)) is None:

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@ setup(
     author_email='info@gandreadis.com',
     license='MIT',
     keywords='sample setuptools development',
-    install_requires=['bs4', 'ics', 'pytz'],
+    install_requires=['beautifulsoup4>=4.6.0', 'bs4', 'ics', 'pytz'],
 )


### PR DESCRIPTION
- The CSS selector on line 34 (main.py) selected irrelevant stuff from time to time. Added a class limit.
- The program doesn't work with the older version of BeautifulSoup. Added dependency version check (also a reference to the main package rather than the bs4 dummy).
- Chrome (at least on Mac) does not save the right html file. Added a note to README.md.